### PR TITLE
[feat] adapter 기능 일부 구현

### DIFF
--- a/src/main/java/com/example/hex/application/ports/in/RouterNetworkInputPort.java
+++ b/src/main/java/com/example/hex/application/ports/in/RouterNetworkInputPort.java
@@ -6,7 +6,9 @@ import com.example.hex.domain.entity.Router;
 import com.example.hex.domain.service.NetworkOperation;
 import com.example.hex.domain.vo.Network;
 import com.example.hex.domain.vo.RouterId;
+import org.springframework.stereotype.Component;
 
+@Component
 public class RouterNetworkInputPort implements RouterNetworkUseCase {
     private final RouterNetworkOutputPort routerNetworkOutputPort;
 

--- a/src/main/java/com/example/hex/domain/vo/IP.java
+++ b/src/main/java/com/example/hex/domain/vo/IP.java
@@ -4,11 +4,18 @@ public class IP {
     private final String address;
     private final Protocol protocol;
 
-    public IP(String address, Protocol protocol) {
-        if (address == null) throw new IllegalArgumentException("NULL IP address");
-
-        if (address.length() < 15) this.protocol = Protocol.IPV4;
-        else this.protocol = Protocol.IPV6;
+    private IP(String address){
+        if(address == null)
+            throw new IllegalArgumentException("Null IP address");
         this.address = address;
+        if(address.length()<=15) {
+            this.protocol = Protocol.IPV4;
+        } else {
+            this.protocol = Protocol.IPV6;
+        }
+    }
+
+    public static IP fromAddress(String address){
+        return new IP(address);
     }
 }

--- a/src/main/java/com/example/hex/framework/input/NetworkController.java
+++ b/src/main/java/com/example/hex/framework/input/NetworkController.java
@@ -1,0 +1,21 @@
+package com.example.hex.framework.input;
+
+import com.example.hex.application.usecases.RouterNetworkUseCase;
+import com.example.hex.domain.vo.IP;
+import com.example.hex.domain.vo.Network;
+import com.example.hex.domain.vo.RouterId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+public class NetworkController {
+    private final RouterNetworkUseCase routerNetworkUseCase;
+
+    @GetMapping("/test")
+    void test() {
+        routerNetworkUseCase.addNetworkToRouter(RouterId.withoutId(), new Network(IP.fromAddress(""), "", 1));
+    }
+}

--- a/src/main/java/com/example/hex/framework/output/NetworkJpaAdapter.java
+++ b/src/main/java/com/example/hex/framework/output/NetworkJpaAdapter.java
@@ -1,0 +1,19 @@
+package com.example.hex.framework.output;
+
+import com.example.hex.application.ports.out.RouterNetworkOutputPort;
+import com.example.hex.domain.entity.Router;
+import com.example.hex.domain.vo.RouterId;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NetworkJpaAdapter implements RouterNetworkOutputPort {
+    @Override
+    public Router fetchRouterById(RouterId routerId) {
+        return null;
+    }
+
+    @Override
+    public boolean persistRouter(Router router) {
+        return false;
+    }
+}


### PR DESCRIPTION
### 연습 문제

1. **입력 어댑터는 언제 만들어야 하는가?**
    
    드라이빙 엑터가 액세스해야 하는 소프트웨어 기능을 노출해야 할 때 입력 어댑터를 만든다.
    이러한 액터는 HTTP REST나 명령행 같은 다양한 기술이나 프로토콜을 사용해 헥사고날 애플리케이션에 액세스할 수 있다.
    
2. **여러 입력 어댑터를 같은 입력 포트에 연결하면 어떤 이점이 있는가?**
    
    다양한 입력 어댑터에서 나오는 데이터를 처리하는 데 입력 포트에 담긴 동일한 로직을 사용할 수 있다.
    
3. **출력 어댑터를 만들기 위해서는 반드시 어떤 인터페이스를 구현해야 하는가?**
    
    항상 출력 포트를 따라 구현되어야 한다.
    이를 통해 어댑터가 도메인 모델이 표현하는 요구사항과 일치하는 것을 보장한다.
    
4. **입력 어댑터와 출력 어댑터는 어떤 헥사곤에 속하는가?**
    
    둘 다 프레임워크 헥사곤에 속한다.